### PR TITLE
Add check for if key ends in .png in BitMapFontProvider

### DIFF
--- a/api/src/main/java/team/unnamed/creative/font/BitMapFontProvider.java
+++ b/api/src/main/java/team/unnamed/creative/font/BitMapFontProvider.java
@@ -165,7 +165,7 @@ public class BitMapFontProvider implements FontProvider {
     public void serialize(ResourceWriter writer) {
         writer.startObject()
                 .key("type").value("bitmap")
-                .key("file").value(file);
+                .key("file").value(file.asString().endsWith(".png") ? file : file.asString() + ".png");
 
         if (height != BitMapFontProvider.DEFAULT_HEIGHT) {
             // only write if height is not equal to the default height


### PR DESCRIPTION
If key does not end in .png, append it.