### PR TITLE
feat: add ResourcePackPart interface

### DIFF
--- a/api/src/main/java/team/unnamed/creative/atlas/Atlas.java
+++ b/api/src/main/java/team/unnamed/creative/atlas/Atlas.java
@@ -31,6 +31,8 @@ import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
+import team.unnamed.creative.overlay.ResourceContainer;
+import team.unnamed.creative.part.ResourcePackPart;
 
 import java.util.List;
 
@@ -57,7 +59,7 @@ import java.util.List;
  * @since 1.0.0
  */
 @ApiStatus.NonExtendable
-public interface Atlas extends Keyed, Examinable {
+public interface Atlas extends ResourcePackPart, Keyed, Examinable {
 
     Key BLOCKS = Key.key("blocks");
     Key BANNER_PATTERNS = Key.key("banner_patterns");
@@ -107,6 +109,17 @@ public interface Atlas extends Keyed, Examinable {
      */
     @Contract("-> new")
     @NotNull Builder toBuilder();
+
+    /**
+     * Adds this atlas instance to the given resource container.
+     *
+     * @param resourceContainer The resource container
+     * @since 1.1.0
+     */
+    @Override
+    default void addTo(final @NotNull ResourceContainer resourceContainer) {
+        resourceContainer.atlas(this);
+    }
 
     /**
      * Creates a new {@link Atlas} instance.

--- a/api/src/main/java/team/unnamed/creative/blockstate/BlockState.java
+++ b/api/src/main/java/team/unnamed/creative/blockstate/BlockState.java
@@ -28,6 +28,8 @@ import net.kyori.adventure.key.Keyed;
 import net.kyori.examination.Examinable;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+import team.unnamed.creative.overlay.ResourceContainer;
+import team.unnamed.creative.part.ResourcePackPart;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -47,7 +49,7 @@ import java.util.Map;
  * @since 1.0.0
  */
 @ApiStatus.NonExtendable
-public interface BlockState extends Keyed, Examinable {
+public interface BlockState extends ResourcePackPart, Keyed, Examinable {
 
     @Override
     @NotNull Key key();
@@ -55,6 +57,17 @@ public interface BlockState extends Keyed, Examinable {
     Map<String, MultiVariant> variants();
 
     List<Selector> multipart();
+
+    /**
+     * Adds this block state to the given resource container
+     *
+     * @param resourceContainer The resource container
+     * @since 1.1.0
+     */
+    @Override
+    default void addTo(final @NotNull ResourceContainer resourceContainer) {
+        resourceContainer.blockState(this);
+    }
 
     /**
      * Creates a new {@link BlockState} object from

--- a/api/src/main/java/team/unnamed/creative/font/Font.java
+++ b/api/src/main/java/team/unnamed/creative/font/Font.java
@@ -29,6 +29,8 @@ import net.kyori.examination.Examinable;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
+import team.unnamed.creative.overlay.ResourceContainer;
+import team.unnamed.creative.part.ResourcePackPart;
 
 import java.util.Arrays;
 import java.util.List;
@@ -43,7 +45,7 @@ import java.util.List;
  * @since 1.0.0
  */
 @ApiStatus.NonExtendable
-public interface Font extends Keyed, Examinable {
+public interface Font extends ResourcePackPart, Keyed, Examinable {
     Key MINECRAFT_DEFAULT = Key.key("default");
     Key MINECRAFT_ALT = Key.key("alt");
     Key MINECRAFT_ILLAGERALT = Key.key("illageralt");
@@ -170,6 +172,17 @@ public interface Font extends Keyed, Examinable {
         return font()
                 .key(this.key())
                 .providers(this.providers());
+    }
+
+    /**
+     * Adds this font to the given resource container.
+     *
+     * @param resourceContainer The resource container
+     * @since 1.1.0
+     */
+    @Override
+    default void addTo(final @NotNull ResourceContainer resourceContainer) {
+        resourceContainer.font(this);
     }
 
     /**

--- a/api/src/main/java/team/unnamed/creative/lang/Language.java
+++ b/api/src/main/java/team/unnamed/creative/lang/Language.java
@@ -33,6 +33,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import team.unnamed.creative.metadata.language.LanguageEntry;
 import team.unnamed.creative.metadata.language.LanguageMeta;
+import team.unnamed.creative.overlay.ResourceContainer;
+import team.unnamed.creative.part.ResourcePackPart;
 
 import java.util.Map;
 
@@ -49,7 +51,7 @@ import static java.util.Objects.requireNonNull;
  * @since 1.0.0
  */
 @ApiStatus.NonExtendable
-public interface Language extends Keyed, Examinable {
+public interface Language extends ResourcePackPart, Keyed, Examinable {
     /**
      * Creates a new {@link Language} object which holds
      * the given translations in a Map.
@@ -150,6 +152,17 @@ public interface Language extends Keyed, Examinable {
     default @Nullable String translation(final @NotNull Translatable translatable) {
         requireNonNull(translatable, "translatable");
         return translation(translatable.translationKey());
+    }
+
+    /**
+     * Adds this language to the given resource container.
+     *
+     * @param resourceContainer The resource container
+     * @since 1.1.0
+     */
+    @Override
+    default void addTo(final @NotNull ResourceContainer resourceContainer) {
+        resourceContainer.language(this);
     }
 
     /**

--- a/api/src/main/java/team/unnamed/creative/model/Model.java
+++ b/api/src/main/java/team/unnamed/creative/model/Model.java
@@ -31,6 +31,8 @@ import net.kyori.examination.string.StringExaminer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
+import team.unnamed.creative.overlay.ResourceContainer;
+import team.unnamed.creative.part.ResourcePackPart;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -47,7 +49,7 @@ import static java.util.Objects.requireNonNull;
  *
  * @since 1.0.0
  */
-public class Model implements Keyed, Examinable {
+public class Model implements ResourcePackPart, Keyed, Examinable {
 
     /**
      * A {@link Model} can be set to extend this key to use
@@ -179,6 +181,17 @@ public class Model implements Keyed, Examinable {
      */
     public List<ItemOverride> overrides() {
         return overrides;
+    }
+
+    /**
+     * Adds this model to the given resource container.
+     *
+     * @param resourceContainer The resource container
+     * @since 1.1.0
+     */
+    @Override
+    public void addTo(@NotNull ResourceContainer resourceContainer) {
+        resourceContainer.model(this);
     }
 
     /**

--- a/api/src/main/java/team/unnamed/creative/overlay/Overlay.java
+++ b/api/src/main/java/team/unnamed/creative/overlay/Overlay.java
@@ -26,7 +26,9 @@ package team.unnamed.creative.overlay;
 import org.intellij.lang.annotations.Subst;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+import team.unnamed.creative.ResourcePack;
 import team.unnamed.creative.metadata.overlays.OverlayEntry;
+import team.unnamed.creative.part.ResourcePackPart;
 
 /**
  * Represents a resource-pack overlay. Overlays are sub-packs
@@ -43,23 +45,39 @@ import team.unnamed.creative.metadata.overlays.OverlayEntry;
  * <p>Also note that overlays do not have pack metadata or
  * icon.</p>
  *
- * @since 1.1.0
  * @sincePackFormat 18
  * @sinceMinecraft 1.20.2
+ * @since 1.1.0
  */
 @ApiStatus.NonExtendable
-public interface Overlay extends ResourceContainer {
+public interface Overlay extends ResourcePackPart, ResourceContainer {
 
     /**
      * Gets the overlay's directory name.
      *
      * @return The overlay directory name.
-     * @since 1.1.0
      * @sincePackFormat 18
      * @sinceMinecraft 1.20.2
+     * @since 1.1.0
      */
     @Subst("dir")
     @NotNull String directory();
+
+    /**
+     * Adds this overlay to the given resource container,
+     * which must be a resource pack.
+     *
+     * @param resourceContainer The resource container
+     * @since 1.1.0
+     */
+    @Override
+    default void addTo(final @NotNull ResourceContainer resourceContainer) {
+        if (resourceContainer instanceof ResourcePack) {
+            ((ResourcePack) resourceContainer).overlay(this);
+        } else {
+            throw new IllegalArgumentException("Cannot add an Overlay to a resource container that is not a resource pack.");
+        }
+    }
 
     /**
      * Creates a new overlay object that will live in the given
@@ -67,9 +85,9 @@ public interface Overlay extends ResourceContainer {
      *
      * @param directory The overlay directory name.
      * @return The created overlay.
-     * @since 1.1.0
      * @sincePackFormat 18
      * @sinceMinecraft 1.20.2
+     * @since 1.1.0
      */
     static @NotNull Overlay create(final @NotNull @OverlayEntry.Directory String directory) {
         return new OverlayImpl(directory);

--- a/api/src/main/java/team/unnamed/creative/overlay/ResourceContainer.java
+++ b/api/src/main/java/team/unnamed/creative/overlay/ResourceContainer.java
@@ -35,6 +35,7 @@ import team.unnamed.creative.font.FontProvider;
 import team.unnamed.creative.lang.Language;
 import team.unnamed.creative.metadata.Metadata;
 import team.unnamed.creative.model.Model;
+import team.unnamed.creative.part.ResourcePackPart;
 import team.unnamed.creative.sound.Sound;
 import team.unnamed.creative.sound.SoundEvent;
 import team.unnamed.creative.sound.SoundRegistry;
@@ -175,6 +176,17 @@ public interface ResourceContainer {
     }
     //#endregion
     //#endregion
+
+    /**
+     * Adds the given resource pack part to this resource container.
+     *
+     * @param part The resource pack part
+     * @since 1.1.0
+     */
+    default void part(final @NotNull ResourcePackPart part) {
+        requireNonNull(part, "part");
+        part.addTo(this);
+    }
 
     //#region Unknown Files (By absolute path)
     void unknownFile(final @NotNull String path, final @NotNull Writable data);

--- a/api/src/main/java/team/unnamed/creative/part/ResourcePackPart.java
+++ b/api/src/main/java/team/unnamed/creative/part/ResourcePackPart.java
@@ -1,0 +1,100 @@
+/*
+ * This file is part of creative, licensed under the MIT license
+ *
+ * Copyright (c) 2021-2023 Unnamed Team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package team.unnamed.creative.part;
+
+import org.jetbrains.annotations.NotNull;
+import team.unnamed.creative.overlay.ResourceContainer;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+
+/**
+ * Represents a resource-pack part.
+ *
+ * <p>The resource-pack part can contain one or multiple
+ * resource-pack elements that can be added to an existing
+ * resource-pack.</p>
+ *
+ * <p>This interface allows developers to extract parts
+ * of the resource-pack in different objects</p>
+ *
+ * <p>See the following example on making a "serializer" that
+ * converts custom blocks to something that can be written to
+ * a resource-pack.</p>
+ * <pre>{@code
+ *  interface CustomBlockSerializer<T> {
+ *      T serialize(CustomBlock block);
+ *  }
+ *
+ *  class ResourcePackCustomBlockSerializer implements CustomBlockSerializer<ResourcePackPart> {
+ *      @Override
+ *      public ResourcePackPart serialize(CustomBlock block) {
+ *          return ResourcePackPart.compound(
+ *              BlockState.blockState(...),
+ *              Texture.texture(...),
+ *              Model.model(...)
+ *          );
+ *      }
+ *  }
+ * }</pre>
+ *
+ * @since 1.1.0
+ */
+public interface ResourcePackPart {
+
+    /**
+     * Adds the resource-pack part to the given
+     * {@code resourceContainer}.
+     *
+     * @param resourceContainer The resource container
+     * @since 1.1.0
+     */
+    void addTo(final @NotNull ResourceContainer resourceContainer);
+
+    /**
+     * Creates a new resource-pack part that is compound
+     * of the given {@code parts}.
+     *
+     * @param parts The resource pack parts
+     * @return The new resource-pack part
+     * @since 1.1.0
+     */
+    static @NotNull ResourcePackPart compound(final @NotNull Collection<? extends ResourcePackPart> parts) {
+        return new ResourcePackPartCompound(new ArrayList<>(parts));
+    }
+
+    /**
+     * Creates a new resource-pack part that is compound
+     * of the given {@code parts}.
+     *
+     * @param parts The resource pack parts
+     * @return The new resource-pack part
+     * @since 1.1.0
+     */
+    static @NotNull ResourcePackPart compound(final @NotNull ResourcePackPart @NotNull ... parts) {
+        return compound(Arrays.asList(parts));
+    }
+
+}

--- a/api/src/main/java/team/unnamed/creative/part/ResourcePackPartCompound.java
+++ b/api/src/main/java/team/unnamed/creative/part/ResourcePackPartCompound.java
@@ -1,0 +1,77 @@
+/*
+ * This file is part of creative, licensed under the MIT license
+ *
+ * Copyright (c) 2021-2023 Unnamed Team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package team.unnamed.creative.part;
+
+import net.kyori.examination.Examinable;
+import net.kyori.examination.ExaminableProperty;
+import net.kyori.examination.string.StringExaminer;
+import org.jetbrains.annotations.NotNull;
+import team.unnamed.creative.overlay.ResourceContainer;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static java.util.Objects.requireNonNull;
+
+final class ResourcePackPartCompound implements ResourcePackPart, Examinable {
+
+    private final List<ResourcePackPart> parts;
+
+    ResourcePackPartCompound(List<ResourcePackPart> parts) {
+        this.parts = requireNonNull(parts, "parts");
+    }
+
+    @Override
+    public void addTo(final @NotNull ResourceContainer resourceContainer) {
+        for (final ResourcePackPart part : parts) {
+            part.addTo(resourceContainer);
+        }
+    }
+
+    @Override
+    public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+        return Stream.of(
+                ExaminableProperty.of("parts", parts)
+        );
+    }
+
+    @Override
+    public String toString() {
+        return examine(StringExaminer.simpleEscaping());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ResourcePackPartCompound that = (ResourcePackPartCompound) o;
+        return parts.equals(that.parts);
+    }
+
+    @Override
+    public int hashCode() {
+        return parts.hashCode();
+    }
+
+}

--- a/api/src/main/java/team/unnamed/creative/part/package-info.java
+++ b/api/src/main/java/team/unnamed/creative/part/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * This file is part of creative, licensed under the MIT license
+ *
+ * Copyright (c) 2021-2023 Unnamed Team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/**
+ * Provides classes that represent abstract parts of a resource-pack.
+ */
+package team.unnamed.creative.part;

--- a/api/src/main/java/team/unnamed/creative/sound/Sound.java
+++ b/api/src/main/java/team/unnamed/creative/sound/Sound.java
@@ -30,6 +30,8 @@ import net.kyori.examination.ExaminableProperty;
 import net.kyori.examination.string.StringExaminer;
 import org.jetbrains.annotations.NotNull;
 import team.unnamed.creative.base.Writable;
+import team.unnamed.creative.overlay.ResourceContainer;
+import team.unnamed.creative.part.ResourcePackPart;
 import team.unnamed.creative.texture.Texture;
 
 import java.util.Objects;
@@ -43,7 +45,7 @@ import static java.util.Objects.requireNonNull;
  *
  * @since 1.0.0
  */
-public final class Sound implements Keyed, Examinable {
+public final class Sound implements ResourcePackPart, Keyed, Examinable {
 
     private final Key key;
     private final Writable data;
@@ -81,6 +83,17 @@ public final class Sound implements Keyed, Examinable {
      */
     public Writable data() {
         return data;
+    }
+
+    /**
+     * Adds this sound to the given resource container.
+     *
+     * @param resourceContainer The resource container
+     * @since 1.1.0
+     */
+    @Override
+    public void addTo(final @NotNull ResourceContainer resourceContainer) {
+        resourceContainer.sound(this);
     }
 
     @Override

--- a/api/src/main/java/team/unnamed/creative/sound/SoundEvent.java
+++ b/api/src/main/java/team/unnamed/creative/sound/SoundEvent.java
@@ -31,6 +31,8 @@ import net.kyori.examination.string.StringExaminer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
+import team.unnamed.creative.overlay.ResourceContainer;
+import team.unnamed.creative.part.ResourcePackPart;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -47,7 +49,7 @@ import static team.unnamed.creative.util.MoreCollections.immutableListOf;
  *
  * @since 1.0.0
  */
-public class SoundEvent implements Sound.Type, Examinable  {
+public class SoundEvent implements ResourcePackPart, Sound.Type, Examinable {
 
     public static final boolean DEFAULT_REPLACE = false;
 
@@ -108,6 +110,17 @@ public class SoundEvent implements Sound.Type, Examinable  {
         return sounds;
     }
 
+    /**
+     * Adds this sound event to the given resource container.
+     *
+     * @param resourceContainer The resource container
+     * @since 1.1.0
+     */
+    @Override
+    public void addTo(final @NotNull ResourceContainer resourceContainer) {
+        resourceContainer.soundEvent(this);
+    }
+
     @Override
     public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
         return Stream.of(
@@ -141,10 +154,10 @@ public class SoundEvent implements Sound.Type, Examinable  {
      * Creates a new {@link SoundEvent} from the
      * given values
      *
-     * @param key The sound event's key
-     * @param replace True to replace default sounds
+     * @param key      The sound event's key
+     * @param replace  True to replace default sounds
      * @param subtitle The sound event subtitle
-     * @param sounds The sound event sounds
+     * @param sounds   The sound event sounds
      * @return A new {@link SoundEvent} instance
      * @since 1.0.0
      */

--- a/api/src/main/java/team/unnamed/creative/sound/SoundRegistry.java
+++ b/api/src/main/java/team/unnamed/creative/sound/SoundRegistry.java
@@ -32,6 +32,8 @@ import org.intellij.lang.annotations.Pattern;
 import org.intellij.lang.annotations.Subst;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import team.unnamed.creative.overlay.ResourceContainer;
+import team.unnamed.creative.part.ResourcePackPart;
 import team.unnamed.creative.util.Keys;
 
 import java.util.Collection;
@@ -50,7 +52,7 @@ import static java.util.Objects.requireNonNull;
  *
  * @since 1.0.0
  */
-public class SoundRegistry implements Namespaced, Examinable {
+public class SoundRegistry implements ResourcePackPart, Namespaced, Examinable {
 
     @Subst(Key.MINECRAFT_NAMESPACE)
     private final String namespace;
@@ -86,6 +88,17 @@ public class SoundRegistry implements Namespaced, Examinable {
     public @Nullable SoundEvent sound(Key key) {
         requireNonNull(key, "key");
         return sounds.get(key);
+    }
+
+    /**
+     * Adds this sound registry to the given resource container.
+     *
+     * @param resourceContainer The resource container
+     * @since 1.1.0
+     */
+    @Override
+    public void addTo(final @NotNull ResourceContainer resourceContainer) {
+        resourceContainer.soundRegistry(this);
     }
 
     @Override

--- a/api/src/main/java/team/unnamed/creative/texture/Texture.java
+++ b/api/src/main/java/team/unnamed/creative/texture/Texture.java
@@ -36,6 +36,8 @@ import team.unnamed.creative.metadata.Metadatable;
 import team.unnamed.creative.metadata.animation.AnimationMeta;
 import team.unnamed.creative.metadata.texture.TextureMeta;
 import team.unnamed.creative.metadata.villager.VillagerMeta;
+import team.unnamed.creative.overlay.ResourceContainer;
+import team.unnamed.creative.part.ResourcePackPart;
 
 /**
  * Represents a Minecraft texture (PNG image) in the
@@ -52,7 +54,7 @@ import team.unnamed.creative.metadata.villager.VillagerMeta;
  * @since 1.0.0
  */
 @ApiStatus.NonExtendable
-public interface Texture extends Keyed, Examinable, Metadatable {
+public interface Texture extends ResourcePackPart, Keyed, Examinable, Metadatable {
     /**
      * Creates a texture.
      *
@@ -225,6 +227,17 @@ public interface Texture extends Keyed, Examinable, Metadatable {
         return builder()
                 .key(this.key())
                 .data(this.data());
+    }
+
+    /**
+     * Adds this texture to the given resource container.
+     *
+     * @param resourceContainer The resource container
+     * @since 1.1.0
+     */
+    @Override
+    default void addTo(final @NotNull ResourceContainer resourceContainer) {
+        resourceContainer.texture(this);
     }
 
     /**


### PR DESCRIPTION
# ResourcePackPart
***(Feedback required)***

The `ResourcePackPart` represents anything that can be added to a resource-pack. It may be one or multiple resource-pack elements like `Font`, `Texture`, `Model` (which also implement `ResourcePackPart` now).

This is a usage example from the Javadocs:
```java
interface CustomBlockSerializer<T> {
    T serialize(CustomBlock block);
}

class ResourcePackCustomBlockSerializer implements CustomBlockSerializer<ResourcePackPart> {
    @Override
    public ResourcePackPart serialize(CustomBlock block) {
         // this is the same as returning (container) -> { container.blockState(BlockState.blockState(...)); ... }
         return ResourcePackPart.compound(
             BlockState.blockState(...),
             Texture.texture(...),
             Model.model(...)
         );
     }
 }
```
This just moves the interaction with `ResourcePack`/`ResourceContainer` one level deeper, but could be used to perform some analysis on the resources before actually adding them to a resource-pack