### PR TITLE
Add Model#toBuilder method

### DIFF
--- a/api/src/main/java/team/unnamed/creative/model/Model.java
+++ b/api/src/main/java/team/unnamed/creative/model/Model.java
@@ -158,6 +158,25 @@ public interface Model extends ResourcePackPart, Keyed, Examinable {
     @NotNull List<ItemOverride> overrides();
 
     /**
+     * Converts this model object to a {@link Builder}
+     * with all the model-properties in this object.
+     *
+     * @return The builder
+     * @since 1.3.0
+     */
+    @Contract("-> new")
+    @NotNull default Builder toBuilder() {
+        return Model.model().key(key())
+                .parent(parent())
+                .ambientOcclusion(ambientOcclusion())
+                .display(display())
+                .textures(textures())
+                .guiLight(guiLight())
+                .elements(elements())
+                .overrides(overrides());
+    }
+
+    /**
      * Adds this model to the given resource container.
      *
      * @param resourceContainer The resource container


### PR DESCRIPTION
Convenience method to let you convert a Model to a builder for further manipulating it
Useful if you are trying to merge resourcepacks and avoid overriding one

So instead of this:
```java
List<ItemOverride> overrides = new ArrayList<>();
Model baseModel = resourcePack.model(baseKey);
if (baseModel == null) Model.model().build();
Model.Builder modelBuilder = Model.model().key(baseModel.key()).parent(baseModel.parent()).textures(baseModel.textures());
modelBuilder.overrides(overrides);
```

You could do:
```java
List<ItemOverride> overrides = new ArrayList<>();
Model baseModel = resourcePack.model(baseKey);
if (baseModel == null) Model.model().build();
baseModel = baseModel.toBuilder().overrides(overrides).build();
```