### PR TITLE
Fix Texture toBuilder()

### DIFF
--- a/api/src/main/java/team/unnamed/creative/texture/Texture.java
+++ b/api/src/main/java/team/unnamed/creative/texture/Texture.java
@@ -226,7 +226,8 @@ public interface Texture extends ResourcePackPart, Keyed, Examinable, Metadatabl
     default @NotNull Builder toBuilder() {
         return builder()
                 .key(this.key())
-                .data(this.data());
+                .data(this.data())
+                .meta(this.meta());
     }
 
     /**


### PR DESCRIPTION
when using Texture.toBuilder() the metadata is lost