### PR TITLE
feat: replacing HashMap with LinkedHashMap

### DIFF
--- a/api/src/main/java/team/unnamed/creative/ResourcePackImpl.java
+++ b/api/src/main/java/team/unnamed/creative/ResourcePackImpl.java
@@ -29,21 +29,21 @@ import team.unnamed.creative.base.Writable;
 import team.unnamed.creative.metadata.Metadata;
 import team.unnamed.creative.metadata.MetadataPart;
 import team.unnamed.creative.metadata.overlays.OverlayEntry;
-import team.unnamed.creative.resources.MergeStrategy;
 import team.unnamed.creative.overlay.Overlay;
 import team.unnamed.creative.overlay.ResourceContainer;
 import team.unnamed.creative.overlay.ResourceContainerImpl;
+import team.unnamed.creative.resources.MergeStrategy;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
 
 final class ResourcePackImpl extends ResourceContainerImpl implements ResourcePack {
 
-    private final Map<String, Overlay> overlays = new HashMap<>();
+    private final Map<String, Overlay> overlays = new LinkedHashMap<>();
 
     private @Nullable Writable icon;
     private Metadata metadata;

--- a/api/src/main/java/team/unnamed/creative/font/SpaceFontProvider.java
+++ b/api/src/main/java/team/unnamed/creative/font/SpaceFontProvider.java
@@ -27,7 +27,7 @@ import net.kyori.examination.ExaminableProperty;
 import net.kyori.examination.string.StringExaminer;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
@@ -121,7 +121,7 @@ public class SpaceFontProvider implements FontProvider {
 
         public Builder advance(String character, int value) {
             if (this.advances == null) {
-                this.advances = new HashMap<>();
+                this.advances = new LinkedHashMap<>();
             }
             this.advances.put(character, value);
             return this;

--- a/api/src/main/java/team/unnamed/creative/metadata/MetadataImpl.java
+++ b/api/src/main/java/team/unnamed/creative/metadata/MetadataImpl.java
@@ -31,7 +31,7 @@ import org.jetbrains.annotations.Unmodifiable;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
@@ -99,7 +99,7 @@ final class MetadataImpl implements Metadata {
     }
 
     static final class BuilderImpl implements Builder {
-        private final Map<Class<?>, MetadataPart> parts = new HashMap<>();
+        private final Map<Class<?>, MetadataPart> parts = new LinkedHashMap<>();
 
         @Override
         public @NotNull Builder parts(final @NotNull Collection<MetadataPart> parts) {

--- a/api/src/main/java/team/unnamed/creative/model/ElementImpl.java
+++ b/api/src/main/java/team/unnamed/creative/model/ElementImpl.java
@@ -30,7 +30,7 @@ import org.jetbrains.annotations.Unmodifiable;
 import team.unnamed.creative.base.CubeFace;
 import team.unnamed.creative.base.Vector3Float;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
@@ -138,7 +138,7 @@ final class ElementImpl implements Element {
         private Vector3Float to;
         private ElementRotation rotation = null;
         private boolean shade = DEFAULT_SHADE;
-        private Map<CubeFace, ElementFace> faces = new HashMap<>();
+        private Map<CubeFace, ElementFace> faces = new LinkedHashMap<>();
 
 
         @Override
@@ -167,7 +167,7 @@ final class ElementImpl implements Element {
 
         @Override
         public @NotNull Builder faces(final @NotNull Map<CubeFace, ElementFace> faces) {
-            this.faces = new HashMap<>(requireNonNull(faces, "faces"));
+            this.faces = new LinkedHashMap<>(requireNonNull(faces, "faces"));
             return this;
         }
 

--- a/api/src/main/java/team/unnamed/creative/model/ModelImpl.java
+++ b/api/src/main/java/team/unnamed/creative/model/ModelImpl.java
@@ -31,7 +31,7 @@ import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -152,7 +152,7 @@ final class ModelImpl implements Model {
         private Key key;
         private Key parent;
         private boolean ambientOcclusion = DEFAULT_AMBIENT_OCCLUSION;
-        private Map<ItemTransform.Type, ItemTransform> display = new HashMap<>();
+        private Map<ItemTransform.Type, ItemTransform> display = new LinkedHashMap<>();
         private ModelTextures textures = ModelTextures.EMPTY;
         private GuiLight guiLight;
         private List<Element> elements = new ArrayList<>();
@@ -179,7 +179,7 @@ final class ModelImpl implements Model {
         @Override
         public @NotNull Builder display(final @NotNull Map<ItemTransform.Type, ItemTransform> display) {
             requireNonNull(display, "display");
-            this.display = new HashMap<>(display);
+            this.display = new LinkedHashMap<>(display);
             return this;
         }
 

--- a/api/src/main/java/team/unnamed/creative/model/ModelTextures.java
+++ b/api/src/main/java/team/unnamed/creative/model/ModelTextures.java
@@ -35,7 +35,7 @@ import org.jetbrains.annotations.Unmodifiable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -237,7 +237,7 @@ public class ModelTextures implements Examinable {
         @Contract("_ -> this")
         public @NotNull Builder variables(final @NotNull Map<String, ModelTexture> variables) {
             requireNonNull(variables, "variables");
-            this.variables = new HashMap<>(variables);
+            this.variables = new LinkedHashMap<>(variables);
             return this;
         }
 
@@ -246,7 +246,7 @@ public class ModelTextures implements Examinable {
             requireNonNull(id, "id");
             requireNonNull(texture, "texture");
             if (variables == null) {
-                variables = new HashMap<>();
+                variables = new LinkedHashMap<>();
             }
             variables.put(id, texture);
             return this;

--- a/api/src/main/java/team/unnamed/creative/overlay/ResourceContainerImpl.java
+++ b/api/src/main/java/team/unnamed/creative/overlay/ResourceContainerImpl.java
@@ -45,7 +45,7 @@ import team.unnamed.creative.texture.Texture;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -56,17 +56,17 @@ import static java.util.Objects.requireNonNull;
 @ApiStatus.Internal
 public class ResourceContainerImpl implements ResourceContainer {
 
-    private final Map<Key, Atlas> atlases = new HashMap<>();
-    private final Map<Key, BlockState> blockStates = new HashMap<>();
-    private final Map<Key, Font> fonts = new HashMap<>();
-    private final Map<Key, Language> languages = new HashMap<>();
-    private final Map<Key, Model> models = new HashMap<>();
-    private final Map<String, SoundRegistry> soundRegistries = new HashMap<>();
-    private final Map<Key, Sound> sounds = new HashMap<>();
-    private final Map<Key, Texture> textures = new HashMap<>();
+    private final Map<Key, Atlas> atlases = new LinkedHashMap<>();
+    private final Map<Key, BlockState> blockStates = new LinkedHashMap<>();
+    private final Map<Key, Font> fonts = new LinkedHashMap<>();
+    private final Map<Key, Language> languages = new LinkedHashMap<>();
+    private final Map<Key, Model> models = new LinkedHashMap<>();
+    private final Map<String, SoundRegistry> soundRegistries = new LinkedHashMap<>();
+    private final Map<Key, Sound> sounds = new LinkedHashMap<>();
+    private final Map<Key, Texture> textures = new LinkedHashMap<>();
 
     // Unknown files we don't know how to parse
-    private final Map<String, Writable> files = new HashMap<>();
+    private final Map<String, Writable> files = new LinkedHashMap<>();
 
     //#region Atlases (Keyed)
     @Override
@@ -348,7 +348,7 @@ public class ResourceContainerImpl implements ResourceContainer {
                 continue;
             }
 
-            final Map<String, String> translations = new HashMap<>(oldLanguage.translations());
+            final Map<String, String> translations = new LinkedHashMap<>(oldLanguage.translations());
             for (final Map.Entry<String, String> translation : language.translations().entrySet()) {
                 final String replaced = translations.put(translation.getKey(), translation.getValue());
                 if (replaced != null && strategy == MergeStrategy.mergeAndFailOnError()) {
@@ -386,7 +386,7 @@ public class ResourceContainerImpl implements ResourceContainer {
                 continue;
             }
 
-            final Map<Key, SoundEvent> soundEvents = new HashMap<>();
+            final Map<Key, SoundEvent> soundEvents = new LinkedHashMap<>();
             for (final SoundEvent soundEvent : oldSoundRegistry.sounds()) {
                 soundEvents.put(soundEvent.key(), soundEvent);
             }

--- a/api/src/main/java/team/unnamed/creative/sound/SoundRegistryImpl.java
+++ b/api/src/main/java/team/unnamed/creative/sound/SoundRegistryImpl.java
@@ -34,8 +34,9 @@ import org.jetbrains.annotations.Unmodifiable;
 import team.unnamed.creative.util.Keys;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -55,7 +56,7 @@ final class SoundRegistryImpl implements SoundRegistry {
     ) {
         this.namespace = requireNonNull(namespace, "namespace");
         requireNonNull(sounds, "sounds");
-        this.sounds = new HashMap<>();
+        this.sounds = new LinkedHashMap<>();
         for (SoundEvent soundEvent : sounds) {
             this.sounds.put(soundEvent.key(), soundEvent);
         }
@@ -138,7 +139,7 @@ final class SoundRegistryImpl implements SoundRegistry {
         @Override
         public @NotNull Builder sounds(final @NotNull Collection<? extends SoundEvent> sounds) {
             requireNonNull(sounds, "sounds");
-            this.sounds = new HashSet<>(sounds);
+            this.sounds = new LinkedHashSet<>(sounds);
             return this;
         }
 

--- a/api/src/main/java/team/unnamed/creative/util/MoreCollections.java
+++ b/api/src/main/java/team/unnamed/creative/util/MoreCollections.java
@@ -27,7 +27,7 @@ import org.jetbrains.annotations.ApiStatus;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -49,7 +49,7 @@ public final class MoreCollections {
     public static <K, V> Map<K, V> immutableMapOf(Map<K, V> map) {
         return map.isEmpty()
                 ? Collections.emptyMap()
-                : Collections.unmodifiableMap(new HashMap<>(map));
+                : Collections.unmodifiableMap(new LinkedHashMap<>(map));
     }
 
 }

--- a/serializer-minecraft/src/main/java/team/unnamed/creative/serialize/minecraft/MinecraftResourcePackReaderImpl.java
+++ b/serializer-minecraft/src/main/java/team/unnamed/creative/serialize/minecraft/MinecraftResourcePackReaderImpl.java
@@ -49,6 +49,8 @@ import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Queue;
 
@@ -77,7 +79,7 @@ final class MinecraftResourcePackReaderImpl implements MinecraftResourcePackRead
         // waiting for textures (because we can't know the order
         // they come in)
         // (null key means it is root resource pack)
-        Map<@Nullable String, Map<Key, Texture>> incompleteTextures = new HashMap<>();
+        Map<@Nullable String, Map<Key, Texture>> incompleteTextures = new LinkedHashMap<>();
 
         while (reader.hasNext()) {
             String path = reader.next();
@@ -212,7 +214,7 @@ final class MinecraftResourcePackReaderImpl implements MinecraftResourcePackRead
                     Key key = Key.key(namespace, keyOfMetadata);
                     Metadata metadata = MetadataSerializer.INSTANCE.readFromTree(parseJson(reader.stream()));
 
-                    Map<Key, Texture> incompleteTexturesThisContainer = incompleteTextures.computeIfAbsent(overlayDir, k -> new HashMap<>());
+                    Map<Key, Texture> incompleteTexturesThisContainer = incompleteTextures.computeIfAbsent(overlayDir, k -> new LinkedHashMap<>());
                     Texture texture = incompleteTexturesThisContainer.remove(key);
                     if (texture == null) {
                         // metadata was found first, put
@@ -224,7 +226,7 @@ final class MinecraftResourcePackReaderImpl implements MinecraftResourcePackRead
                 } else {
                     Key key = Key.key(namespace, categoryPath);
                     Writable data = reader.content().asWritable();
-                    Map<Key, Texture> incompleteTexturesThisContainer = incompleteTextures.computeIfAbsent(overlayDir, k -> new HashMap<>());
+                    Map<Key, Texture> incompleteTexturesThisContainer = incompleteTextures.computeIfAbsent(overlayDir, k -> new LinkedHashMap<>());
                     Texture waiting = incompleteTexturesThisContainer.remove(key);
 
                     if (waiting == null) {

--- a/serializer-minecraft/src/main/java/team/unnamed/creative/serialize/minecraft/ResourceCategories.java
+++ b/serializer-minecraft/src/main/java/team/unnamed/creative/serialize/minecraft/ResourceCategories.java
@@ -32,7 +32,7 @@ import team.unnamed.creative.serialize.minecraft.model.ModelSerializer;
 import team.unnamed.creative.serialize.minecraft.sound.SoundSerializer;
 
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class ResourceCategories {
@@ -40,7 +40,7 @@ public class ResourceCategories {
     private static final Map<String, ResourceCategory<?>> CATEGORIES;
 
     static {
-        CATEGORIES = new HashMap<>();
+        CATEGORIES = new LinkedHashMap<>();
         registerCategory(AtlasSerializer.CATEGORY);
         registerCategory(SoundSerializer.CATEGORY);
         registerCategory(ModelSerializer.CATEGORY);

--- a/serializer-minecraft/src/main/java/team/unnamed/creative/serialize/minecraft/atlas/AtlasSourceSerializer.java
+++ b/serializer-minecraft/src/main/java/team/unnamed/creative/serialize/minecraft/atlas/AtlasSourceSerializer.java
@@ -42,7 +42,7 @@ import team.unnamed.creative.serialize.minecraft.base.KeySerializer;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -216,7 +216,7 @@ final class AtlasSourceSerializer {
             @Subst("minecraft:resource")
             String paletteKeyStr = node.get("palette_key").getAsString();
             Key paletteKey = Key.key(paletteKeyStr);
-            Map<String, Key> permutations = new HashMap<>();
+            Map<String, Key> permutations = new LinkedHashMap<>();
             for (Map.Entry<String, JsonElement> entry : node.getAsJsonObject("permutations").entrySet()) {
                 @Subst("minecraft:resource")
                 String value = entry.getValue().getAsString();

--- a/serializer-minecraft/src/main/java/team/unnamed/creative/serialize/minecraft/blockstate/BlockStateSerializer.java
+++ b/serializer-minecraft/src/main/java/team/unnamed/creative/serialize/minecraft/blockstate/BlockStateSerializer.java
@@ -41,7 +41,7 @@ import team.unnamed.creative.serialize.minecraft.io.JsonResourceSerializer;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -95,7 +95,7 @@ public final class BlockStateSerializer implements JsonResourceSerializer<BlockS
 
         JsonObject objectNode = node.getAsJsonObject();
 
-        Map<String, MultiVariant> variants = new HashMap<>();
+        Map<String, MultiVariant> variants = new LinkedHashMap<>();
         List<Selector> multipart = new ArrayList<>();
 
         // read variants

--- a/serializer-minecraft/src/main/java/team/unnamed/creative/serialize/minecraft/font/FontSerializer.java
+++ b/serializer-minecraft/src/main/java/team/unnamed/creative/serialize/minecraft/font/FontSerializer.java
@@ -46,7 +46,7 @@ import team.unnamed.creative.serialize.minecraft.io.JsonResourceSerializer;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -194,7 +194,7 @@ public final class FontSerializer implements JsonResourceSerializer<Font>, JsonR
 
     private static SpaceFontProvider readSpace(JsonObject node) {
         JsonObject advancesNode = node.getAsJsonObject("advances");
-        Map<String, Integer> advances = new HashMap<>();
+        Map<String, Integer> advances = new LinkedHashMap<>();
         for (Map.Entry<String, JsonElement> advanceEntryNode : advancesNode.entrySet()) {
             String character = advanceEntryNode.getKey();
             int advance = advanceEntryNode.getValue().getAsInt();

--- a/serializer-minecraft/src/main/java/team/unnamed/creative/serialize/minecraft/language/LanguageSerializer.java
+++ b/serializer-minecraft/src/main/java/team/unnamed/creative/serialize/minecraft/language/LanguageSerializer.java
@@ -34,7 +34,7 @@ import team.unnamed.creative.serialize.minecraft.io.JsonResourceDeserializer;
 import team.unnamed.creative.serialize.minecraft.io.JsonResourceSerializer;
 
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public final class LanguageSerializer implements JsonResourceSerializer<Language>, JsonResourceDeserializer<Language> {
@@ -70,7 +70,7 @@ public final class LanguageSerializer implements JsonResourceSerializer<Language
     @Override
     public Language deserializeFromJson(JsonElement node, Key key) {
         JsonObject objectNode = node.getAsJsonObject();
-        Map<String, String> translations = new HashMap<>();
+        Map<String, String> translations = new LinkedHashMap<>();
 
         for (Map.Entry<String, JsonElement> translationEntry : objectNode.entrySet()) {
             String translationKey = translationEntry.getKey();

--- a/serializer-minecraft/src/main/java/team/unnamed/creative/serialize/minecraft/metadata/LanguageMetaCodec.java
+++ b/serializer-minecraft/src/main/java/team/unnamed/creative/serialize/minecraft/metadata/LanguageMetaCodec.java
@@ -32,7 +32,7 @@ import team.unnamed.creative.metadata.language.LanguageMeta;
 import team.unnamed.creative.serialize.minecraft.GsonUtil;
 
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 final class LanguageMetaCodec implements MetadataPartCodec<LanguageMeta> {
@@ -49,7 +49,7 @@ final class LanguageMetaCodec implements MetadataPartCodec<LanguageMeta> {
 
     @Override
     public @NotNull LanguageMeta read(final @NotNull JsonObject node) {
-        Map<String, LanguageEntry> languages = new HashMap<>();
+        Map<String, LanguageEntry> languages = new LinkedHashMap<>();
 
         for (Map.Entry<String, JsonElement> entry : node.entrySet()) {
             String code = entry.getKey();

--- a/serializer-minecraft/src/main/java/team/unnamed/creative/serialize/minecraft/metadata/MetadataSerializer.java
+++ b/serializer-minecraft/src/main/java/team/unnamed/creative/serialize/minecraft/metadata/MetadataSerializer.java
@@ -32,13 +32,14 @@ import team.unnamed.creative.serialize.minecraft.io.JsonResourceSerializer;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class MetadataSerializer implements JsonResourceSerializer<Metadata> {
 
     public static final MetadataSerializer INSTANCE = new MetadataSerializer();
 
-    private static final Map<String, MetadataPartCodec<?>> CODECS = new HashMap<>();
+    private static final Map<String, MetadataPartCodec<?>> CODECS = new LinkedHashMap<>();
 
     static {
         registerCodec(AnimationMetaCodec.INSTANCE);

--- a/serializer-minecraft/src/main/java/team/unnamed/creative/serialize/minecraft/model/ModelSerializer.java
+++ b/serializer-minecraft/src/main/java/team/unnamed/creative/serialize/minecraft/model/ModelSerializer.java
@@ -53,7 +53,7 @@ import team.unnamed.creative.texture.TextureUV;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -145,7 +145,7 @@ public final class ModelSerializer implements JsonResourceSerializer<Model>, Jso
         }
 
         // display
-        Map<ItemTransform.Type, ItemTransform> display = new HashMap<>();
+        Map<ItemTransform.Type, ItemTransform> display = new LinkedHashMap<>();
         if (objectNode.has("display")) {
             JsonObject displayNode = objectNode.getAsJsonObject("display");
             for (Map.Entry<String, JsonElement> entry : displayNode.entrySet()) {
@@ -278,7 +278,7 @@ public final class ModelSerializer implements JsonResourceSerializer<Model>, Jso
             rotation = readElementRotation(objectNode.get("rotation"));
         }
 
-        Map<CubeFace, ElementFace> faces = new HashMap<>();
+        Map<CubeFace, ElementFace> faces = new LinkedHashMap<>();
         for (Map.Entry<String, JsonElement> entry : objectNode.getAsJsonObject("faces").entrySet()) {
             CubeFace face = CubeFace.valueOf(entry.getKey().toUpperCase(Locale.ROOT));
             JsonObject elementFaceNode = entry.getValue().getAsJsonObject();
@@ -487,7 +487,7 @@ public final class ModelSerializer implements JsonResourceSerializer<Model>, Jso
         JsonObject objectNode = node.getAsJsonObject();
         ModelTexture particle = null;
         List<ModelTexture> layers = new ArrayList<>(objectNode.entrySet().size());
-        Map<String, ModelTexture> variables = new HashMap<>();
+        Map<String, ModelTexture> variables = new LinkedHashMap<>();
 
         for (Map.Entry<String, JsonElement> entry : objectNode.entrySet()) {
             String key = entry.getKey();

--- a/serializer-minecraft/src/main/java/team/unnamed/creative/serialize/minecraft/sound/SoundRegistrySerializer.java
+++ b/serializer-minecraft/src/main/java/team/unnamed/creative/serialize/minecraft/sound/SoundRegistrySerializer.java
@@ -38,6 +38,7 @@ import team.unnamed.creative.sound.SoundRegistry;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -116,7 +117,7 @@ public final class SoundRegistrySerializer implements JsonResourceSerializer<Sou
     }
 
     public SoundRegistry readFromTree(JsonElement node, @Subst("minecraft") String namespace) {
-        Set<SoundEvent> soundEvents = new HashSet<>();
+        Set<SoundEvent> soundEvents = new LinkedHashSet<>();
         JsonObject objectNode = node.getAsJsonObject();
 
         for (Map.Entry<String, JsonElement> soundEventEntry : objectNode.entrySet()) {
@@ -140,7 +141,7 @@ public final class SoundRegistrySerializer implements JsonResourceSerializer<Sou
                         // complete sound object
                         JsonObject soundObjectNode = soundNode.getAsJsonObject();
 
-                        SoundEntry.Builder sound = SoundEntry.builder()
+                        SoundEntry.Builder sound = SoundEntry.soundEntry()
                                 .key(Key.key(soundObjectNode.get("name").getAsString()))
                                 .volume(GsonUtil.getFloat(soundObjectNode, "volume", SoundEntry.DEFAULT_VOLUME))
                                 .pitch(GsonUtil.getFloat(soundObjectNode, "pitch", SoundEntry.DEFAULT_PITCH))


### PR DESCRIPTION
If you have the code to generate a resourcepack and you call the Creative methods in the same order, with the same inputs, you will end up with different resourcepacks in two runs.
This pull request fixes the problem by replacing all HashMap with LinkedHashMap