### PR TITLE
Ignore invalid item transform types on item models

### DIFF
--- a/serializer-minecraft/src/main/java/team/unnamed/creative/serialize/minecraft/model/ModelSerializer.java
+++ b/serializer-minecraft/src/main/java/team/unnamed/creative/serialize/minecraft/model/ModelSerializer.java
@@ -148,8 +148,12 @@ public final class ModelSerializer implements JsonResourceSerializer<Model>, Jso
         if (objectNode.has("display")) {
             JsonObject displayNode = objectNode.getAsJsonObject("display");
             for (Map.Entry<String, JsonElement> entry : displayNode.entrySet()) {
-                ItemTransform.Type type = ItemTransform.Type.valueOf(entry.getKey().toUpperCase(Locale.ROOT));
-                display.put(type, readItemTransform(entry.getValue()));
+                try {
+                    ItemTransform.Type type = ItemTransform.Type.valueOf(entry.getKey().toUpperCase(Locale.ROOT));
+                    display.put(type, readItemTransform(entry.getValue()));
+                } catch (IllegalArgumentException e) {
+                    // ignore unknown display types like the vanilla client does
+                }
             }
         }
 


### PR DESCRIPTION
This fixes an issue where an error would be thrown when processing an item model with a non-standard item transform type. The vanilla client ignores any invalid types.

Example: https://github.com/Graclyxz/Many-More-Ores-and-Crafts/blob/941837076ee80e0e616e74330508d496ca10b10a/common/src/main/resources/assets/many_more_ores_and_crafts/models/item/tin_ore.json
This will cause the `valueOf` call to fail as `thirdperson` isn't a valid option. Following this change it will safely ignore the exception thrown and allow parsing to continue.