### PR TITLE
Add texts support

### DIFF
--- a/api/src/main/java/team/unnamed/creative/overlay/ResourceContainer.java
+++ b/api/src/main/java/team/unnamed/creative/overlay/ResourceContainer.java
@@ -28,6 +28,7 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import team.unnamed.creative.atlas.Atlas;
+import team.unnamed.creative.base.Readable;
 import team.unnamed.creative.base.Writable;
 import team.unnamed.creative.blockstate.BlockState;
 import team.unnamed.creative.equipment.Equipment;
@@ -676,6 +677,34 @@ public interface ResourceContainer {
         requireNonNull(part, "part");
         part.addTo(this);
     }
+
+    //#region Texts (Keyed)
+    /**
+     * Sets a texts file in this resource container.
+     *
+     * @param content The content of the text to add into the pack
+     * @since 1.8.4
+     */
+    void texts(final @NotNull Key key, final @NotNull Writable content);
+
+    /**
+     * Gets the text with the given key.
+     *
+     * @param key The text key
+     * @return The text, null if not found
+     * @since 1.8.4
+     */
+    @Nullable Writable texts(final @NotNull Key key);
+
+    /**
+     * Gets all the texts in this resource container.
+     * The returned map cannot be modified.
+     *
+     * @return The texts
+     * @since 1.8.4
+     */
+    @NotNull Map<Key, Writable> texts();
+    //#endregion
 
     //#region Unknown Files (By path, relative to current's resource container)
 

--- a/api/src/main/java/team/unnamed/creative/overlay/ResourceContainer.java
+++ b/api/src/main/java/team/unnamed/creative/overlay/ResourceContainer.java
@@ -28,7 +28,6 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import team.unnamed.creative.atlas.Atlas;
-import team.unnamed.creative.base.Readable;
 import team.unnamed.creative.base.Writable;
 import team.unnamed.creative.blockstate.BlockState;
 import team.unnamed.creative.equipment.Equipment;

--- a/api/src/main/java/team/unnamed/creative/overlay/ResourceContainerImpl.java
+++ b/api/src/main/java/team/unnamed/creative/overlay/ResourceContainerImpl.java
@@ -29,6 +29,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import team.unnamed.creative.atlas.Atlas;
 import team.unnamed.creative.atlas.AtlasSource;
+import team.unnamed.creative.base.Readable;
 import team.unnamed.creative.base.Writable;
 import team.unnamed.creative.blockstate.BlockState;
 import team.unnamed.creative.equipment.Equipment;
@@ -49,6 +50,7 @@ import team.unnamed.creative.texture.Texture;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -70,6 +72,7 @@ public class ResourceContainerImpl implements ResourceContainer {
     private final Map<String, SoundRegistry> soundRegistries = new LinkedHashMap<>();
     private final Map<Key, Sound> sounds = new LinkedHashMap<>();
     private final Map<Key, Texture> textures = new LinkedHashMap<>();
+    private final Map<Key, Writable> texts = new LinkedHashMap<>();
 
     // Unknown files we don't know how to parse
     private final Map<String, Writable> files = new LinkedHashMap<>();
@@ -321,6 +324,23 @@ public class ResourceContainerImpl implements ResourceContainer {
     @Override
     public @NotNull Collection<Texture> textures() {
         return textures.values();
+    }
+    //#endregion
+
+    //#region Texts
+    @Override
+    public void texts(final @NotNull Key key, final @NotNull Writable splashTexts) {
+        this.texts.put(key, splashTexts);
+    }
+
+    @Override
+    public @Nullable Writable texts(@NotNull Key key) {
+        return this.texts.get(key);
+    }
+
+    @Override
+    public @NotNull Map<Key, Writable> texts() {
+        return Collections.unmodifiableMap(this.texts);
     }
     //#endregion
 

--- a/api/src/main/java/team/unnamed/creative/overlay/ResourceContainerImpl.java
+++ b/api/src/main/java/team/unnamed/creative/overlay/ResourceContainerImpl.java
@@ -29,7 +29,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import team.unnamed.creative.atlas.Atlas;
 import team.unnamed.creative.atlas.AtlasSource;
-import team.unnamed.creative.base.Readable;
 import team.unnamed.creative.base.Writable;
 import team.unnamed.creative.blockstate.BlockState;
 import team.unnamed.creative.equipment.Equipment;

--- a/docs/texts.md
+++ b/docs/texts.md
@@ -1,0 +1,25 @@
+## Texts
+
+Minecraft supports modifying texts that appear in-game. This
+includes various texts such as splash texts, end text and the credits.
+
+### Interacting with texts
+
+Interacting with texts can be done by either adding texts or reading them.
+Below is an example with splash texts.
+
+<!--@formatter:off-->
+```java
+// Reading...
+Writable content = pack.texts(Key.key(Key.MINECRAFT_NAMESPACE, "splashes"));
+
+List<String> texts = content.toUTF8String().split("\n");
+
+// Writing...
+pack.texts(
+        Key.key(Key.MINECRAFT_NAMESPACE, "splashes"),
+        Writable.stringUtf8(String.join("\n", texts))
+);
+```
+<!--@formatter:on-->
+

--- a/serializer-minecraft/src/main/java/team/unnamed/creative/serialize/minecraft/MinecraftResourcePackReaderImpl.java
+++ b/serializer-minecraft/src/main/java/team/unnamed/creative/serialize/minecraft/MinecraftResourcePackReaderImpl.java
@@ -268,6 +268,13 @@ final class MinecraftResourcePackReaderImpl implements MinecraftResourcePackRead
                         ));
                     }
                 }
+            } else if (categoryName.equals(TEXTS_FOLDER)) {
+                String textKey = withoutExtension(categoryPath, TEXT_EXTENSION);
+                if (textKey != null) {
+                    Key key = Key.key(namespace, textKey);
+
+                    container.texts(key, reader.content().asWritable());
+                }
             } else {
                 // get the resource category, if the local pack format (overlay or root) is the same as the
                 // root pack format, we can use the previously computed map, otherwise we need to compute it

--- a/serializer-minecraft/src/main/java/team/unnamed/creative/serialize/minecraft/MinecraftResourcePackStructure.java
+++ b/serializer-minecraft/src/main/java/team/unnamed/creative/serialize/minecraft/MinecraftResourcePackStructure.java
@@ -41,6 +41,7 @@ public final class MinecraftResourcePackStructure {
     public static final String TEXTURE_EXTENSION = ".png";
     public static final String METADATA_EXTENSION = ".mcmeta";
     public static final String OBJECT_EXTENSION = ".json";
+    public static final String TEXT_EXTENSION = ".txt";
 
     public static final String FILE_SEPARATOR = "/";
 

--- a/serializer-minecraft/src/main/java/team/unnamed/creative/serialize/minecraft/MinecraftResourcePackWriterImpl.java
+++ b/serializer-minecraft/src/main/java/team/unnamed/creative/serialize/minecraft/MinecraftResourcePackWriterImpl.java
@@ -24,6 +24,7 @@
 package team.unnamed.creative.serialize.minecraft;
 
 import com.google.gson.stream.JsonWriter;
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.key.Keyed;
 import org.jetbrains.annotations.NotNull;
 import team.unnamed.creative.ResourcePack;
@@ -48,6 +49,7 @@ import team.unnamed.creative.texture.Texture;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -130,6 +132,14 @@ final class MinecraftResourcePackWriterImpl implements MinecraftResourcePackWrit
             if (!metadata.parts().isEmpty()) {
                 writeToJson(target, MetadataSerializer.INSTANCE, metadata, basePath + MinecraftResourcePackStructure.pathOfMeta(texture), localTargetPackFormat);
             }
+        }
+
+        // write texts
+        for (Map.Entry<Key, Writable> text : container.texts().entrySet()) {
+            target.write(
+                    String.format("%sassets/%s/texts/%s.txt", basePath, text.getKey().namespace(), text.getKey().value()),
+                    text.getValue()
+            );
         }
 
         // write unknown files


### PR DESCRIPTION
Add texts support into creative, adds the following:
- API to read and write from the texts folder
- Reading and writing of texts in the texts folder in `serializer-minecraft`
- Some documentation on texts

*To note*, I am unable to currently test writing texts, but likely works.