### PR TITLE
fix: read directory entries in name order so packs are reproducible

### DIFF
--- a/serializer-minecraft/src/main/java/team/unnamed/creative/serialize/minecraft/fs/DirectoryFileTreeReader.java
+++ b/serializer-minecraft/src/main/java/team/unnamed/creative/serialize/minecraft/fs/DirectoryFileTreeReader.java
@@ -31,6 +31,8 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.NoSuchElementException;
 
@@ -61,11 +63,17 @@ final class DirectoryFileTreeReader implements FileTreeReader {
                 }
 
                 File folder = folders.get(folderCursor++);
-                files = folder.listFiles();
+                File[] children = folder.listFiles();
 
-                if (files == null) {
+                if (children == null) {
                     throw new IllegalStateException("Null children from file " + folder);
                 }
+
+                // listFiles() returns entries in whatever order the file system
+                // stores them, which is not the same on every machine. sorting by
+                // name means the same folder is always read in the same order
+                Arrays.sort(children, Comparator.comparing(File::getName));
+                files = children;
             }
 
             while (fileCursor < files.length) {

--- a/serializer-minecraft/src/test/java/team/unnamed/creative/serialize/minecraft/fs/DirectoryFileTreeReaderTest.java
+++ b/serializer-minecraft/src/test/java/team/unnamed/creative/serialize/minecraft/fs/DirectoryFileTreeReaderTest.java
@@ -23,13 +23,48 @@
  */
 package team.unnamed.creative.serialize.minecraft.fs;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class DirectoryFileTreeReaderTest implements FileTreeReaderTest {
 
     @Override
     public FileTreeReader createReader() {
         return FileTreeReader.directory(new File("src/test/resources/folder"));
+    }
+
+    @Test
+    @DisplayName("Test that a directory is always read in the same order")
+    void test_read_order_is_sorted_by_name(final @TempDir Path root) throws IOException {
+        // written in an order that is not alphabetical, so a reader that follows
+        // the file system order is unlikely to match the expected list below
+        Files.write(root.resolve("z.txt"), "z".getBytes());
+        Files.write(root.resolve("m.txt"), "m".getBytes());
+        Files.write(root.resolve("a.txt"), "a".getBytes());
+
+        final Path sub = Files.createDirectory(root.resolve("sub"));
+        Files.write(sub.resolve("y.txt"), "y".getBytes());
+        Files.write(sub.resolve("b.txt"), "b".getBytes());
+
+        final List<String> paths = new ArrayList<>();
+        try (FileTreeReader reader = FileTreeReader.directory(root.toFile())) {
+            while (reader.hasNext()) {
+                paths.add(reader.next());
+            }
+        }
+
+        assertEquals(Arrays.asList("a.txt", "m.txt", "z.txt", "sub/b.txt", "sub/y.txt"), paths);
     }
 
 }


### PR DESCRIPTION
`DirectoryFileTreeReader` walks a folder with `File.listFiles()`, which returns entries in whatever order the file system stores them. That order is a property of the file system rather than of the files, so two machines holding the same folder can read it in two different orders.

`ResourceContainerImpl` keeps its resources in `LinkedHashMap`s and `MinecraftResourcePackWriter` writes them in insertion order, so the read order becomes the zip entry order. Two servers with identical files then build packs that have identical content but different bytes, and so different hashes.

I hit this on a Minecraft network where two backends held byte-identical resource files and produced a different pack hash each. The two servers had separate ext4 file systems, and ext4 orders directory entries by a hash of the file name seeded with a random value written at mkfs time, so the two orders never matched. It does not reproduce on a single machine, because both directories are then on the same file system.

This sorts each folder's entries by name before reading them, so the read order depends only on the file names.

The added test writes files in a non-alphabetical order and checks that the reader returns them sorted. Without the change it fails with:

```
expected: [a.txt, m.txt, z.txt, sub/b.txt, sub/y.txt]
but was:  [z.txt, m.txt, a.txt, sub/y.txt, sub/b.txt]
```

All 41 tests in `creative-serializer-minecraft` pass with the change.

One unrelated note: `creative-api` does not compile on `main` right now, because `SpecialRender.playerHead()` is declared twice, at lines 167 and 277. I patched that locally so I could run the tests, and left it out of this branch.
